### PR TITLE
add exception for LRB approved pytest-metadata

### DIFF
--- a/dependency-review-config.yml
+++ b/dependency-review-config.yml
@@ -13,4 +13,5 @@ allow_licenses:
 allow-dependencies-licenses:
   - pkg:githubactions/fossas/fossa-action
   - pkg:golang/github.com/shoenig/go-m1cpu
+  - pkg:pypi/pytest-metadata
 comment-summary-in-pr: on-failure


### PR DESCRIPTION
> Category 5 usage of the pytest-metadata package is approved under the terms of the MPL-2.0 license (https://github.com/pytest-dev/pytest-metadata/blob/3.1.1/LICENSE).