### PR TITLE
Add ready for refinement label

### DIFF
--- a/labels.yml
+++ b/labels.yml
@@ -85,3 +85,6 @@
 - color: ffffff
   description: An issue that does not need to be fixed
   name: wontfix
+- color: D9F11E
+  description: An issue that was triaged and it is ready to be refined
+  name: ready for refinement


### PR DESCRIPTION
Added a new label "ready for refinement". We will use it in our process of refine issues before they go in the sprint.