### PR TITLE
Add repo files for nap v5 and nginx plus for ubi8

### DIFF
--- a/files/nap-waf-v5-debian-11.repo
+++ b/files/nap-waf-v5-debian-11.repo
@@ -2,7 +2,7 @@
 # Full path to packages: https://pkgs.nginx.com/app-protect-x-plus/debian/pool/nginx-plus/a/app-protect-module-plus/
 
 Types: deb
-URIs: https://pkgs.nginx.com/app-protect-x-plus/%VERSION%/debian
+URIs: https://pkgs.nginx.com/app-protect-x-plus/debian
 Suites: bullseye
 Components: nginx-plus
 Signed-By: /usr/share/keyrings/nginx-archive-keyring.gpg

--- a/files/nap-waf-v5-debian-12.repo
+++ b/files/nap-waf-v5-debian-12.repo
@@ -2,7 +2,7 @@
 # Full path to packages: https://pkgs.nginx.com/app-protect-x-plus/debian/pool/nginx-plus/a/app-protect-module-plus/
 
 Types: deb
-URIs: https://pkgs.nginx.com/app-protect-x-plus/%VERSION%/debian
+URIs: https://pkgs.nginx.com/app-protect-x-plus/debian
 Suites: bookworm
 Components: nginx-plus
 Signed-By: /usr/share/keyrings/nginx-archive-keyring.gpg

--- a/files/nap-waf-v5-ubi-8.repo
+++ b/files/nap-waf-v5-ubi-8.repo
@@ -1,6 +1,6 @@
 [app-protect]
 name=nginx-app-protect repo
-baseurl=https://pkgs-test.nginx.com/app-protect-x-plus/centos/8/$basearch/
+baseurl=https://pkgs.nginx.com/app-protect-x-plus/centos/8/$basearch/
 sslclientcert=/etc/ssl/nginx/nginx-repo.crt
 sslclientkey=/etc/ssl/nginx/nginx-repo.key
 gpgcheck=0

--- a/files/nap-waf-v5-ubi-8.repo
+++ b/files/nap-waf-v5-ubi-8.repo
@@ -1,4 +1,4 @@
-[app-protect]
+[app-protect-x-plus]
 name=nginx-app-protect repo
 baseurl=https://pkgs.nginx.com/app-protect-x-plus/centos/8/$basearch/
 sslclientcert=/etc/ssl/nginx/nginx-repo.crt

--- a/files/nap-waf-v5-ubi-8.repo
+++ b/files/nap-waf-v5-ubi-8.repo
@@ -1,6 +1,6 @@
 [app-protect]
 name=nginx-app-protect repo
-baseurl=https://pkgs-test.nginx.com/app-protect/centos/8/$basearch/
+baseurl=https://pkgs-test.nginx.com/app-protect-x-plus/centos/8/$basearch/
 sslclientcert=/etc/ssl/nginx/nginx-repo.crt
 sslclientkey=/etc/ssl/nginx/nginx-repo.key
 gpgcheck=0

--- a/files/nap-waf-v5-ubi-8.repo
+++ b/files/nap-waf-v5-ubi-8.repo
@@ -1,0 +1,7 @@
+[app-protect]
+name=nginx-app-protect repo
+baseurl=https://pkgs-test.nginx.com/app-protect/centos/8/$basearch/
+sslclientcert=/etc/ssl/nginx/nginx-repo.crt
+sslclientkey=/etc/ssl/nginx/nginx-repo.key
+gpgcheck=0
+enabled=1

--- a/files/nap-waf-v5-ubi-9.repo
+++ b/files/nap-waf-v5-ubi-9.repo
@@ -1,0 +1,7 @@
+[app-protect]
+name=nginx-app-protect repo
+baseurl=https://pkgs-test.nginx.com/app-protect/centos/9/$basearch/
+sslclientcert=/etc/ssl/nginx/nginx-repo.crt
+sslclientkey=/etc/ssl/nginx/nginx-repo.key
+gpgcheck=0
+enabled=1

--- a/files/nap-waf-v5-ubi-9.repo
+++ b/files/nap-waf-v5-ubi-9.repo
@@ -1,6 +1,6 @@
 [app-protect]
 name=nginx-app-protect repo
-baseurl=https://pkgs-test.nginx.com/app-protect-x-plus/centos/9/$basearch/
+baseurl=https://pkgs.nginx.com/app-protect-x-plus/centos/9/$basearch/
 sslclientcert=/etc/ssl/nginx/nginx-repo.crt
 sslclientkey=/etc/ssl/nginx/nginx-repo.key
 gpgcheck=0

--- a/files/nap-waf-v5-ubi-9.repo
+++ b/files/nap-waf-v5-ubi-9.repo
@@ -1,6 +1,6 @@
 [app-protect]
 name=nginx-app-protect repo
-baseurl=https://pkgs-test.nginx.com/app-protect/centos/9/$basearch/
+baseurl=https://pkgs-test.nginx.com/app-protect-x-plus/centos/9/$basearch/
 sslclientcert=/etc/ssl/nginx/nginx-repo.crt
 sslclientkey=/etc/ssl/nginx/nginx-repo.key
 gpgcheck=0

--- a/files/nap-waf-v5-ubi-9.repo
+++ b/files/nap-waf-v5-ubi-9.repo
@@ -1,4 +1,4 @@
-[app-protect]
+[app-protect-x-plus]
 name=nginx-app-protect repo
 baseurl=https://pkgs.nginx.com/app-protect-x-plus/centos/9/$basearch/
 sslclientcert=/etc/ssl/nginx/nginx-repo.crt

--- a/files/nginx-plus-8.repo
+++ b/files/nginx-plus-8.repo
@@ -1,6 +1,6 @@
 [nginx-plus]
 name=nginx-plus repo
-baseurl=https://pkgs-test.nginx.com/plus/centos/8/$basearch/
+baseurl=https://pkgs.nginx.com/plus/centos/8/$basearch/
 sslclientcert=/etc/ssl/nginx/nginx-repo.crt
 sslclientkey=/etc/ssl/nginx/nginx-repo.key
 gpgcheck=0

--- a/files/nginx-plus-8.repo
+++ b/files/nginx-plus-8.repo
@@ -1,0 +1,7 @@
+[nginx-plus]
+name=nginx-plus repo
+baseurl=https://pkgs-test.nginx.com/plus/centos/8/$basearch/
+sslclientcert=/etc/ssl/nginx/nginx-repo.crt
+sslclientkey=/etc/ssl/nginx/nginx-repo.key
+gpgcheck=0
+enabled=1

--- a/files/nginx-plus-8.repo
+++ b/files/nginx-plus-8.repo
@@ -1,7 +1,0 @@
-[nginx-plus]
-name=nginx-plus repo
-baseurl=https://pkgs.nginx.com/plus/centos/8/$basearch/
-sslclientcert=/etc/ssl/nginx/nginx-repo.crt
-sslclientkey=/etc/ssl/nginx/nginx-repo.key
-gpgcheck=0
-enabled=1


### PR DESCRIPTION
This PR adds repo files for AppProtect v5 packages for UBI 8 and UBI 9.

This PR also updates the existing `nap-waf-v5-debian-12.repo` and `nap-waf-v5-debian-11.repo` files to remove the `%VERSION%` variable.