### PR TITLE
add debian 12 sources for waf and dos

### DIFF
--- a/files/nap-dos-debian-12.repo
+++ b/files/nap-dos-debian-12.repo
@@ -1,0 +1,8 @@
+# NAP DoS repo for debian 12 (bookworm).
+# The VERSION variable needs to be replaced with the version of NGINX Plus you want to install, i.e. R30, or removed.
+
+Types: deb
+URIs: https://pkgs.nginx.com/app-protect-dos/%VERSION%/debian
+Suites: bookworm
+Components: nginx-plus
+Signed-By: /usr/share/keyrings/nginx-archive-keyring.gpg

--- a/files/nap-waf-debian-12.repo
+++ b/files/nap-waf-debian-12.repo
@@ -1,0 +1,15 @@
+# NAP WAF repos for debian 12 (bookworm).
+# The VERSION variable needs to be replaced with the version of NGINX Plus you want to install, i.e. R30, or removed.
+
+Types: deb
+URIs: https://pkgs.nginx.com/app-protect/%VERSION%/debian
+Suites: bookworm
+Components: nginx-plus
+Signed-By: /usr/share/keyrings/nginx-archive-keyring.gpg
+
+# security updates
+Types: deb
+URIs: https://pkgs.nginx.com/app-protect-security-updates/debian
+Suites: bookworm
+Components: nginx-plus
+Signed-By: /usr/share/keyrings/app-protect-archive-keyring.gpg


### PR DESCRIPTION
```
<a href="app-protect_32%2B5.48.0-1~bookworm_amd64.deb">app-protect_32+5.48.0-1~bookworm_amd64.deb</a> 
```
```
<a href="app-protect-dos_32%2B4.4.1-1~bookworm_amd64.deb">app-protect-dos_32+4.4.1-1~bookworm_amd64.deb</a> 
```