### PR TITLE
Remove NIC from label sync job

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -26,7 +26,6 @@ jobs:
         with:
           manifest: labels.yml
           repository: |
-            nginxinc/kubernetes-ingress
             nginxinc/kic-test-containers
             nginxinc/nginx-ingress-helm-operator
             nginxinc/nginx-prometheus-exporter


### PR DESCRIPTION
Allow NIC to manage their own labels